### PR TITLE
🐛 fix frequently used emojis

### DIFF
--- a/src/config.v
+++ b/src/config.v
@@ -3,7 +3,8 @@ import toml
 
 struct Config {
 mut:
-	audio bool
+	audio bool // Last state of audio feedback feedback setting for emoji selections
+	port  int  // Default port the app is tried to be served on.
 }
 
 fn (mut app App) load_config() ! {
@@ -16,6 +17,7 @@ fn (mut app App) load_config() ! {
 	user_config := toml.parse_file(cfg_file)!
 	app.config = Config{
 		audio: user_config.value('audio').default_to(true).bool()
+		port: user_config.value('port').default_to(34763).int()
 	}
 }
 

--- a/src/main.v
+++ b/src/main.v
@@ -33,6 +33,7 @@ fn main() {
 			debug: $if prod { false } $else { true }
 		)
 	}
+	app.load_config() or { panic('Failed loading config. ${err}') }
 	$if dev ? {
 		// `v -d dev run .` aims to connect to an already running `vite dev` server.
 		// (Run `npm run dev` in the `ui/` dir in another terminal.)
@@ -49,7 +50,6 @@ fn main() {
 }
 
 fn (mut app App) run() {
-	app.load_config() or { panic('Failed loading config. ${err}') }
 	app.bind()
 	app.window.set_title('Emoji Mart')
 	app.window.set_size(352, 435, .@none)

--- a/src/serve.v
+++ b/src/serve.v
@@ -1,5 +1,4 @@
 import net
-import rand
 import vweb
 import os
 
@@ -11,9 +10,8 @@ pub fn (mut ctx Context) index() vweb.Result {
 	return ctx.html(os.read_file('${ui_path}/index.html') or { panic(err) })
 }
 
-fn get_idle_port() int {
-	port := rand.int_in_range(1024, 9999) or { panic(err) }
-	mut l := net.listen_tcp(.ip6, ':${port}') or { return get_idle_port() }
+fn get_idle_port(port int) int {
+	mut l := net.listen_tcp(.ip6, ':${port}') or { return get_idle_port(port + 1) }
 	l.close() or { panic(err) }
 	return port
 }
@@ -23,8 +21,7 @@ fn get_idle_port() int {
 // e.g., `npm run preview` or use `serve` and connect to its localhost address.
 // Check out the `use-serve` branch to see an example.
 fn (mut app App) serve() {
-	app.port = get_idle_port()
-	// Serve UI with vweb on localhost.
+	app.port = get_idle_port(app.config.port)
 	spawn fn (port int) {
 		mut web_ctx := Context{}
 		web_ctx.mount_static_folder_at(ui_path, '/')


### PR DESCRIPTION
Closes #1

Uses a fixed default port to allow local storage to work.
The changes implement a configurable default port. If the port is not available, the next available port after the default port will be searched.

Frequently used emojis are updated when launching the app window. This behavior is determined by upstream emoji-mart and might changed in the feature as there are many requests to improve it.

related: https://github.com/missive/emoji-mart/issues/243, https://github.com/missive/emoji-mart/issues/616