### PR TITLE
🐛 fix `v -d dev -cc gcc run .` on windows

### DIFF
--- a/src/dev.v
+++ b/src/dev.v
@@ -1,35 +1,49 @@
 import os
+import term
 
 // Running the application with `v -d dev run .` runs an `npm run dev` process
 // and connects to the localhost port on which the application is being served on.
 [if dev ?]
 fn (mut app App) serve_dev() {
-	which_npm := os.execute('which npm')
-	if which_npm.exit_code != 0 {
-		eprintln('Failed finding `npm`. Make sure `npm` is executable.')
+	npm_path_error := fn () {
+		eprintln('Failed finding node package manager.\nMake sure npm is executable.')
 		exit(0)
 	}
-	mut p := os.new_process(which_npm.output.trim_space())
+	mut npm_path := ''
+	$if windows {
+		paths := os.execute('where npm')
+		if paths.exit_code != 0 {
+			npm_path_error()
+		}
+		for p in paths.output.trim_space().split_into_lines() {
+			if p.contains('npm.cmd') {
+				npm_path = p
+			}
+		}
+	} $else {
+		path := os.execute('which npm')
+		if path.exit_code != 0 {
+			npm_path_error()
+		}
+		npm_path = path.output.trim_space()
+	}
+	if npm_path == '' {
+		npm_path_error()
+	}
+	mut p := os.new_process(npm_path)
+	p.use_pgroup = true
 	p.set_args(['run', 'dev'])
 	p.set_work_folder(ui_path)
 	p.set_redirect_stdio()
 	p.run()
 	for p.is_alive() {
-		// stdout_read() ~= `INFO  Accepting connections at http://localhost:3000`
 		line := p.stdout_read()
 		if line.contains('localhost:') {
-			app.port = line.all_after_last(':').trim_space().int()
+			app.port = term.strip_ansi(line.all_after('localhost:').trim_space()).int()
 			break
 		}
 	}
 	app.dev_proc.main = p
-	// The pids for a node process that is started by `npm run <script>` differ from the `app.dev_proc.main.pid`
-	serve_pids := os.execute('pgrep -f "ui/node_modules/.bin/vite dev"')
-	app.dev_proc.node_pids = if serve_pids.exit_code == 0 {
-		serve_pids.output.split_into_lines()
-	} else {
-		[]string{}
-	}
 	if app.port == 0 {
 		eprintln('Failed serving to localhost.')
 		app.kill_dev_proc()
@@ -39,10 +53,5 @@ fn (mut app App) serve_dev() {
 
 [if dev ?]
 fn (mut app App) kill_dev_proc() {
-	app.dev_proc.main.signal_kill()
-	if app.dev_proc.node_pids.len > 0 {
-		for id in app.dev_proc.node_pids {
-			os.execute('kill ${id}')
-		}
-	}
+	app.dev_proc.main.signal_pgkill()
 }


### PR DESCRIPTION
\+ improve dev process on other platforms by using a pgroup