### PR TITLE
📝 update readme to reflect latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,18 @@
 An emoji picker desktop application - built to serve as an example of using [webview](https://github.com/ttytm/webview) with a modern web framework.
 Nevertheless, it is a real and capable application. So if you just want to use it, nothing should stop you from doing so.
 
-## Application - Usage
+## Contents
+
+- [Application / Usage](#application--usage)
+  - [Installation](#installation)
+  - [Config](#config)
+- [Webview Example / Building and Development](#webview-example--building-and-development)
+  - [Preparation](#preparation)
+  - [Building](#building)
+  - [Building and Running in a Development Context](#building-and-running-in-a-development-context)
+- [Credits](#credits)
+
+## Application / Usage
 
 It is developed with focus on systems running GNU Linux, but can also be used other platforms.
 
@@ -12,14 +23,24 @@ It is developed with focus on systems running GNU Linux, but can also be used ot
   <img width="412" src="https://github.com/ttytm/emoji-mart-desktop/assets/34311583/b01099d8-6883-4c4b-9346-975bf675b0a4">
 </div>
 
-### Usage
+### Installation
 
 - Linux: Download an Appimage from the [releases](https://github.com/ttytm/emoji-mart-desktop/releases) page.
-- macOS/Windows: There is no bundling atm. So it is required to self compile it and keep the binary and ui files side by side.
+- macOS/Windows: There is no bundling atm. So it is required to self compile it and keep the binary and ui files side by side. See [Building](#preparation).
 
-## Webview Example - Building and Development
+### Config
 
-The following steps show how to build and run the application.
+```toml
+# Lin: ~/.config/emoji-mart/
+# Mac: ~/Library/Application Support/emoji-mart/
+# Win: %USERPROFILE%/AppData/Roaming/emoji-mart/
+
+# Default values
+audio = true # enable audio hint on emoji-selection
+frequent = true # display frequently used emojis
+```
+
+## Webview Example / Building and Development
 
 ### Preparation
 
@@ -31,12 +52,12 @@ The following steps show how to build and run the application.
 
 Either pull and install the required V modules step by step, or use V's package manager to install the project into your `.vmodules` dir and take care of the other modules.
 
-- Manual - (you can skip already performed steps)\
+- Step by Step
   Clone the repository
   ```sh
   git clone https://github.com/ttytm/emoji-mart-desktop.git
   ```
-  Install V webview Binding
+  Install webview
   ```sh
   v install --git https://github.com/ttytm/webview
   # Linux/macOS
@@ -44,7 +65,7 @@ Either pull and install the required V modules step by step, or use V's package 
   # Windows
   v run $HOME/.vmodules/webview/build.vsh
   ```
-  Miniaudio - another V module that this app is using
+  Install `miniaudio` - a V module that this app is using
   ```sh
   v install --git https://github.com/Larpon/miniaudio
   ```
@@ -66,10 +87,10 @@ If you just want to build the application for usage you can now run `./build.vsh
 - On macOS and Windows it's currently required that the contents of `dist/` (`emoji-mart` / `emoji-mart.exe` and `ui/`) are kept next to each other.
 - On Linux you can run `./build.vsh --appimage` to build the AppImage.
 
-### Building and Running the App in a Development Context
+### Building and Running in a Development Context
 
-Since we use web technologies for the UI, a good part of the work on it can likely be done via the browser, just like working on a regular web application.
-However, there comes a point where we want to connect our V program and the UI. Below you will find two examples.
+Since we use web technologies for the UI, a good part of the frontend-work can likely be done via the browser, just like working on a regular web application.
+However, there comes a point where we want to connect our V program and the UI.
 
 > **Note**
 > When running and building on Windows, it is recommended to use `gcc` for compilation. E.g.:
@@ -83,21 +104,16 @@ However, there comes a point where we want to connect our V program and the UI. 
 When connecting to a vite dev server features like hot reloading are preserved.
 Just like in the browser most changes on the UI will be immediately reflected in the application window.
 
-- Run the dev server in one terminal instance
+- Run the app with the `dev` flag - this runs a vite dev server and connects to its localhost instance
 
   ```sh
-  cd ui
-  # npm install # install node_modules if it's the first run
-  npm run dev
-  ```
+  # install the node modules if it's the first run
+  # npm i --prefix ui/
 
-- Run the app in a another terminal - connecting to the UI on the running vite dev server
-
-  ```sh
   v -d dev run .
   ```
 
-  Visual example:
+  Visual example (Might be outdated):
 
   https://github.com/ttytm/emoji-mart-desktop/assets/34311583/86ad765c-ab6a-4970-b2ac-a8a00c399989
 
@@ -105,14 +121,16 @@ Just like in the browser most changes on the UI will be immediately reflected in
 
 This is the regular build approach and what our final app is doing.
 
-- Build the UI - using SvelteKit as a static site generator
+- Build the UI - this uses SvelteKit as a static site generator
 
   ```sh
+  # install the node modules if it's the first run
   # npm i --prefix ui/
+
   npm run build --prefix ui/
   ```
 
-- Run the app - using vweb(or e.g. serve) to serve the previously build files locally and connect to it via webview
+- Run the app - this uses vweb to serve the previously build files locally and connect to it via webview
 
   ```sh
   v run .


### PR DESCRIPTION
- remove manual `npm run dev` step from first example, as it's now included in `v -d dev run`
- add config section
- additionally add a table of contents and updates wording