### PR TITLE
✨ add cache to make frequent emojis port independent

### DIFF
--- a/src/api.v
+++ b/src/api.v
@@ -2,10 +2,14 @@ import webview { Event }
 import os
 
 fn (mut app App) bind() {
-	app.window.bind('get_config', app.get_config) // Bind a function method to have the app struct available.
-	app.window.bind('play_audio', app.play_audio)
-	app.window.bind_ctx('toggle_audio', toggle_audio, app) // Alternatively, use the ctx ptr to pass a struct.
+	// Bind a function.
 	app.window.bind('open_in_browser', open_in_browser)
+	// Bind a function method to make the app struct available.
+	app.window.bind('get_config', app.get_config)
+	app.window.bind('get_cache', app.get_cache)
+	app.window.bind('handle_select', app.handle_select)
+	// Alternatively, use `bind_ctx` and use the context pointer to pass a struct.
+	app.window.bind_ctx('toggle_audio', toggle_audio, app)
 }
 
 // The functions we bind do not have to be public. For semantic reasons or
@@ -15,10 +19,11 @@ pub fn (app &App) get_config(e &Event) {
 	e.@return(app.config)
 }
 
-pub fn (app &App) play_audio(_ &Event) {
+pub fn (mut app App) handle_select(e &Event) {
 	if app.config.audio {
 		spawn play_wav_file()
 	}
+	app.cache.frequently = e.string(0)
 }
 
 pub fn toggle_audio(e &Event, mut app App) {
@@ -27,6 +32,10 @@ pub fn toggle_audio(e &Event, mut app App) {
 		spawn play_wav_file()
 	}
 	e.@return(app.config.audio)
+}
+
+pub fn (app &App) get_cache(e &Event) {
+	e.@return(app.cache.frequently)
 }
 
 pub fn open_in_browser(e &Event) {

--- a/src/cache.v
+++ b/src/cache.v
@@ -1,0 +1,21 @@
+import os
+import json
+
+pub struct LocalStorage {
+mut:
+	frequently string
+}
+
+fn (mut cache LocalStorage) load() ! {
+	if !os.is_dir(cache_dir) {
+		os.mkdir_all(cache_dir)!
+	}
+	if !os.is_file(cache_file) {
+		os.write_file(cache_file, json.encode(LocalStorage{}))!
+	}
+	cache = json.decode(LocalStorage, os.read_file(cache_file)!) or { LocalStorage{} }
+}
+
+fn (cache LocalStorage) save() {
+	os.write_file(cache_file, json.encode(cache)) or { panic('Failed saving cache. ${err}') }
+}

--- a/src/config.v
+++ b/src/config.v
@@ -5,7 +5,6 @@ struct Config {
 mut:
 	audio    bool = true // Last state of audio feedback feedback setting for emoji selections
 	frequent bool = true // Controls whether or not frequently used emojis are shown
-	port     int  = 34763 // Default port the app is tried to be served on.
 }
 
 fn (mut config Config) load() ! {
@@ -19,7 +18,6 @@ fn (mut config Config) load() ! {
 	config = Config{
 		audio: user_config.value('audio').bool()
 		frequent: user_config.value('frequent').bool()
-		port: user_config.value('port').int()
 	}
 }
 

--- a/src/main.v
+++ b/src/main.v
@@ -6,6 +6,7 @@ struct App {
 	window &Webview
 mut:
 	config   Config
+	cache    LocalStorage
 	port     int
 	dev_proc DevProc
 }
@@ -31,8 +32,10 @@ const (
 	} $else {
 		'assets/pop.wav'
 	}
-	cfg_dir  = os.join_path(os.config_dir() or { panic(err) }, 'emoji-mart')
-	cfg_file = os.join_path(cfg_dir, 'emoji-mart.toml')
+	cfg_dir    = os.join_path(os.config_dir() or { panic(err) }, 'emoji-mart')
+	cfg_file   = os.join_path(cfg_dir, 'emoji-mart.toml')
+	cache_dir  = os.join_path(os.cache_dir(), 'emoji-mart', 'LocalStorage')
+	cache_file = os.join_path(cache_dir, 'localStorage.json')
 )
 
 fn main() {
@@ -42,6 +45,7 @@ fn main() {
 		)
 	}
 	app.config.load() or { panic('Failed loading config. ${err}') }
+	app.cache.load() or { panic('Failed loading cache. ${err}') }
 	$if dev ? {
 		app.serve_dev()
 	} $else {
@@ -59,11 +63,13 @@ fn (mut app App) run() {
 	app.window.run()
 	app.window.destroy()
 	app.config.save()
+	app.cache.save()
 	app.kill_dev_proc()
 }
 
 fn (mut app App) handle_interrupt(signal os.Signal) {
 	app.config.save()
+	app.cache.save()
 	app.kill_dev_proc()
 	exit(0)
 }

--- a/src/serve.v
+++ b/src/serve.v
@@ -19,7 +19,7 @@ fn get_idle_port(port int) int {
 // The UI of this example builts into a static site.
 // We use vweb to serve to UI on localhost.
 fn (mut app App) serve() {
-	app.port = get_idle_port(app.config.port)
+	app.port = get_idle_port(34763)
 	spawn fn (port int) {
 		mut web_ctx := Context{}
 		web_ctx.mount_static_folder_at('${ui_path}/build', '/')

--- a/ui/src/app.d.ts
+++ b/ui/src/app.d.ts
@@ -18,6 +18,7 @@ type Config = {
 
 // Webview functions
 declare function get_config(): Promise<Config>;
-declare function play_audio(): Promise<void>;
+declare function get_cache(): Promise<string>;
+declare function handle_select(localStorage: string): Promise<void>;
 declare function toggle_audio(): Promise<bool>;
 declare function open_in_browser(uri: string): Promise<void>;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -18,10 +18,11 @@
 			);
 		}
 		navigator.clipboard.writeText(emojiData.native);
-		if ($config.audio) window.play_audio();
+		window.handle_select(localStorage.getItem('emoji-mart.frequently')!);
 	}
 
 	onMount(async () => {
+		localStorage.setItem('emoji-mart.frequently', await window.get_cache());
 		$config = await get_config();
 		pickerElem.appendChild(
 			new Picker({


### PR DESCRIPTION
Incorporates caching.

This keeps emoji-marts frequently used emoji storage work independent of a localhost port. They remain available if the default port changes or is not available for a run.